### PR TITLE
WEB-4029 : File and Image content types don't have WF so we set effective date equal to created date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- WEB-4029 : File and Image content types don't have WF so we set effective date equal to created date
+  [boulch]
 
 
 1.2.4 (2023-12-07)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
             "plone.testing>=5.0.0",
             "plone.app.robotframework[debug]",
             "plone.restapi[test]",
+            "freezegun",
             "mock",
         ],
     },

--- a/src/imio/smartweb/common/profiles/default/metadata.xml
+++ b/src/imio/smartweb/common/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1024</version>
+  <version>1025</version>
   <dependencies>
     <dependency>profile-plone.restapi:default</dependency>
     <dependency>profile-eea.facetednavigation:default</dependency>

--- a/src/imio/smartweb/common/subscribers.py
+++ b/src/imio/smartweb/common/subscribers.py
@@ -2,6 +2,8 @@
 
 from imio.smartweb.common.utils import clean_invisible_char
 from plone import api
+from plone.app.contenttypes.interfaces import IFile
+from plone.app.contenttypes.interfaces import IImage
 from plone.app.dexterity.behaviors.metadata import IBasic
 from plone.app.textfield.value import IRichTextValue
 from plone.app.textfield.value import RichTextValue
@@ -32,6 +34,8 @@ def reindex_breadcrumb(obj, event):
 
 def added_content(obj, event):
     for schema in iterSchemata(obj):
+        if (IFile).providedBy(obj) or (IImage).providedBy(obj):
+            obj.setEffectiveDate(obj.created())
         for name, field in getFields(schema).items():
             value = getattr(obj, name)
             if IRichTextValue.providedBy(value):

--- a/src/imio/smartweb/common/tests/test_subscribers.py
+++ b/src/imio/smartweb/common/tests/test_subscribers.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from DateTime import DateTime
+from freezegun import freeze_time
+from imio.smartweb.common.testing import IMIO_SMARTWEB_COMMON_INTEGRATION_TESTING
+from plone import api
+from plone.app.contenttypes.interfaces import IFile
+from plone.app.contenttypes.interfaces import IImage
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.namedfile.file import NamedBlobFile
+from plone.namedfile.file import NamedBlobImage
+
+import unittest
+
+
+class TestDescription(unittest.TestCase):
+    layer = IMIO_SMARTWEB_COMMON_INTEGRATION_TESTING
+
+    def setUp(self):
+        """Custom shared utility setup for tests"""
+        self.request = self.layer["request"]
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    @freeze_time("2023-12-14 9:00:00")
+    def test_added_content_image(self):
+        # content types for which effective date is equal to created date (thank to subrscriber)
+        content_types = ["File", "Image"]
+        frozen_time = DateTime()
+
+        for ct in content_types:
+            obj = api.content.create(
+                container=self.portal,
+                type=ct,
+                title=f"My {ct}",
+            )
+            if IFile.providedBy(obj):
+                obj.file = NamedBlobFile(data="file data", filename="file.txt")
+
+            elif IImage.providedBy(obj):
+                obj.image = NamedBlobImage(data="file data", filename="file.txt")
+
+            self.assertEqual(obj.effective(), frozen_time)
+            # subscriber added_content fix effective as created date for Image content type
+            self.assertEqual(obj.effective(), obj.created())

--- a/src/imio/smartweb/common/upgrades/configure.zcml
+++ b/src/imio/smartweb/common/upgrades/configure.zcml
@@ -350,4 +350,12 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeStep
+      title="Set effective date equal to created_date for File and Image"
+      source="1024"
+      destination="1025"
+      handler=".upgrades.set_effective_date_equal_to_created_date"
+      profile="imio.smartweb.common:default"
+      />
+
 </configure>

--- a/src/imio/smartweb/common/upgrades/upgrades.py
+++ b/src/imio/smartweb/common/upgrades/upgrades.py
@@ -129,3 +129,20 @@ def fix_missing_values_for_lists(context):
                 obj.iam = []
                 catalog.catalog_object(obj, idxs=["iam"])
                 logger.info(f"Fixed None list for Iam on {obj.absolute_url()}")
+
+
+def set_effective_date_equal_to_created_date(context):
+    """Image and File content types have no workflow
+    So, effective date was 1969/12/31 00:00:00 GMT+1"""
+
+    with api.env.adopt_user(username="admin"):
+        brains = api.content.find(
+            portal_type=[
+                "File",
+                "Image",
+            ]
+        )
+        for brain in brains:
+            obj = brain.getObject()
+            obj.setEffectiveDate(obj.created())
+            obj.reindexObject(idxs=["effective"])


### PR DESCRIPTION
Dear @laulaz ,

Could you merge this pullrequest ? 

Best regards,

Boulch