### PR TITLE
Update resource registries modification time at Zope startup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-4107 : Update resource registries modification time (used as ETag) at Zope startup
+  [laulaz]
 
 
 1.2.15 (2024-05-27)

--- a/src/imio/smartweb/common/subscribers.zcml
+++ b/src/imio/smartweb/common/subscribers.zcml
@@ -1,6 +1,9 @@
 <configure
     xmlns="http://namespaces.zope.org/zope">
 
+  <subscriber for="zope.processlifetime.IProcessStarting"
+              handler=".subscribers.started_zope"/>
+
   <subscriber for="plone.dexterity.interfaces.IDexterityContent
                    zope.lifecycleevent.interfaces.IObjectAddedEvent"
               handler=".subscribers.added_content" />


### PR DESCRIPTION
This is used as cache ETag
This refs WEB-4107