### PR TITLE
feat(cache): ruleset plone.stableResource for image scales

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.22 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-4153 : Ruleset plone.stableResource for image scales
+  [remdub]
 
 
 1.2.21 (2025-01-31)

--- a/src/imio/smartweb/common/caching_overrides.zcml
+++ b/src/imio/smartweb/common/caching_overrides.zcml
@@ -1,0 +1,20 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:cache="http://namespaces.zope.org/cache"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+    <include package="z3c.unconfigure" file="meta.zcml" />
+
+    <unconfigure>
+        <cache:ruleset
+                for="plone.namedfile.scaling.ImageScale"
+                ruleset="plone.content.file"
+                />
+    </unconfigure>
+
+    <cache:ruleset
+        for="plone.namedfile.scaling.ImageScale"
+        ruleset="plone.stableResource"
+    />
+
+</configure>

--- a/src/imio/smartweb/common/configure.zcml
+++ b/src/imio/smartweb/common/configure.zcml
@@ -24,4 +24,6 @@
   <include package=".upgrades" />
   <include package=".viewlets" />
 
+  <includeOverrides file="caching_overrides.zcml" />
+
 </configure>


### PR DESCRIPTION
We are always using a cache_key, so we can cache forever those scales

WEB-4153