### PR TITLE
WEBBDC-2790 : Add new vocabulary to retrieve entities from directory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.2.53 (unreleased)
 -------------------
 
+- Resolve the directory base URL for the remote entities vocabulary from the
+  ``imio.smartweb.common.directory_url`` registry record (falls back to the
+  ``DIRECTORY_URL`` env var / default).
+  [boulch]
+
 - Reduce ``@search`` ``b_size`` to 3000.
   [boulch]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.53 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Reduce ``@search`` ``b_size`` to 3000.
+  [boulch]
 
 
 1.2.52 (2026-04-22)

--- a/src/imio/smartweb/common/config.py
+++ b/src/imio/smartweb/common/config.py
@@ -3,6 +3,8 @@ import os
 # Used to limit description field on all content types
 DESCRIPTION_MAX_LENGTH = 700
 
+DIRECTORY_URL = os.environ.get("DIRECTORY_URL", "https://annuaire.enwallonie.be")
+
 # Used to translated terms from brains metadatas
 # Must be extended by other products
 VOCABULARIES_MAPPING = {

--- a/src/imio/smartweb/common/profiles/default/metadata.xml
+++ b/src/imio/smartweb/common/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1037</version>
+  <version>1039</version>
   <dependencies>
     <dependency>profile-plone.restapi:default</dependency>
     <dependency>profile-eea.facetednavigation:default</dependency>

--- a/src/imio/smartweb/common/profiles/default/registry/registry.xml
+++ b/src/imio/smartweb/common/profiles/default/registry/registry.xml
@@ -990,6 +990,15 @@
     <value>False</value>
   </record>
 
+  <record name="imio.smartweb.common.directory_url">
+    <field type="plone.registry.field.TextLine">
+      <title>Directory base URL</title>
+      <description>Base URL of the directory used to build the remote entities vocabulary (e.g. https://annuaire.enwallonie.be). Leave empty to fall back on the DIRECTORY_URL environment variable / default.</description>
+      <required>False</required>
+    </field>
+    <value></value>
+  </record>
+
   <records prefix="plone.bundles/smartweb-common-suggested_titles"
             interface="Products.CMFPlone.interfaces.IBundleRegistry">
     <value key="enabled">True</value>

--- a/src/imio/smartweb/common/upgrades/configure.zcml
+++ b/src/imio/smartweb/common/upgrades/configure.zcml
@@ -197,6 +197,14 @@
       directory="profiles/1036_to_1037"
       />
 
+  <genericsetup:registerProfile
+      name="upgrade_1037_to_1038"
+      title="Upgrade common from 1037 to 1038"
+      description="Add directory_url registry record"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/1037_to_1038"
+      />
+
   <genericsetup:upgradeStep
       title="Configure first official release"
       description="Run needed registry step"
@@ -588,6 +596,17 @@
     <genericsetup:upgradeDepends
         title="Add IA text accessible button to TinyMCE"
         import_profile="imio.smartweb.common.upgrades:upgrade_1036_to_1037"
+        />
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
+      profile="imio.smartweb.common:default"
+      source="1037"
+      destination="1038"
+      >
+    <genericsetup:upgradeDepends
+        title="Add directory_url registry record"
+        import_profile="imio.smartweb.common.upgrades:upgrade_1037_to_1038"
         />
   </genericsetup:upgradeSteps>
 

--- a/src/imio/smartweb/common/upgrades/profiles/1038_to_1039/registry.xml
+++ b/src/imio/smartweb/common/upgrades/profiles/1038_to_1039/registry.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<registry>
+
+  <record name="imio.smartweb.common.directory_url">
+    <field type="plone.registry.field.TextLine">
+      <title>Directory base URL</title>
+      <description>Base URL of the directory used to build the remote entities vocabulary (e.g. https://annuaire.enwallonie.be). Leave empty to fall back on the DIRECTORY_URL environment variable / default.</description>
+      <required>False</required>
+    </field>
+    <value></value>
+  </record>
+
+</registry>

--- a/src/imio/smartweb/common/utils.py
+++ b/src/imio/smartweb/common/utils.py
@@ -20,10 +20,34 @@ from zope.i18n import translate
 from zope.schema import getFields
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 
 import geopy
+import json
+import logging
 import re
+import requests
 import unicodedata
+
+logger = logging.getLogger("imio.smartweb.core")
+
+
+def get_json(url, auth=None, timeout=5):
+    language = api.portal.get_current_language()
+    headers = {"Accept": "application/json", "Cookie": f"I18N_LANGUAGE={language}"}
+    if auth is not None:
+        headers["Authorization"] = auth
+    try:
+        response = requests.get(url, headers=headers, timeout=timeout)
+    except requests.exceptions.Timeout:
+        logger.warning(f"Timeout raised for requests : {url}")
+        return None
+    except Exception:
+        return None
+    if response.status_code != 200:
+        return None
+    if response.text:
+        return json.loads(response.text)
 
 
 def get_vocabulary(voc_name, obj=None):
@@ -43,6 +67,25 @@ def get_term_from_vocabulary(vocabulary, value):
     except LookupError:
         return SimpleTerm(value=value, title=value)
     return term
+
+
+def get_entities_vocabulary(portal_type, base_url):
+    params = [
+        "portal_type={}".format(portal_type),
+        "sort_on=sortable_title",
+        "b_size=3000",
+        "metadata_fields=UID",
+    ]
+    url = "{}/@search?{}".format(base_url, "&".join(params))
+    json_entities = get_json(url)
+    if json_entities is None or len(json_entities.get("items", [])) == 0:
+        return SimpleVocabulary([])
+    return SimpleVocabulary(
+        [
+            SimpleTerm(value=elem["UID"], title=elem["title"])
+            for elem in json_entities.get("items")
+        ]
+    )
 
 
 def translate_vocabulary_term(vocabulary, term, lang=None):

--- a/src/imio/smartweb/common/vocabularies.py
+++ b/src/imio/smartweb/common/vocabularies.py
@@ -165,7 +165,13 @@ ScalesVocabulary = ScalesVocabularyFactory()
 
 class RemoteDirectoryEntitiesVocabularyFactory:
     def __call__(self, context=None):
-        return get_entities_vocabulary("imio.directory.Entity", DIRECTORY_URL)
+        directory_url = (
+            api.portal.get_registry_record(
+                "imio.smartweb.common.directory_url", default=""
+            )
+            or DIRECTORY_URL
+        )
+        return get_entities_vocabulary("imio.directory.Entity", directory_url)
 
 
 RemoteDirectoryEntitiesVocabulary = RemoteDirectoryEntitiesVocabularyFactory()

--- a/src/imio/smartweb/common/vocabularies.py
+++ b/src/imio/smartweb/common/vocabularies.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-
+from imio.smartweb.common.config import DIRECTORY_URL
+from imio.smartweb.common.utils import get_entities_vocabulary
 from imio.smartweb.locales import SmartwebMessageFactory as _
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -160,3 +161,11 @@ class ScalesVocabularyFactory:
 
 
 ScalesVocabulary = ScalesVocabularyFactory()
+
+
+class RemoteDirectoryEntitiesVocabularyFactory:
+    def __call__(self, context=None):
+        return get_entities_vocabulary("imio.directory.Entity", DIRECTORY_URL)
+
+
+RemoteDirectoryEntitiesVocabulary = RemoteDirectoryEntitiesVocabularyFactory()

--- a/src/imio/smartweb/common/vocabularies.zcml
+++ b/src/imio/smartweb/common/vocabularies.zcml
@@ -43,4 +43,10 @@
       provides="zope.schema.interfaces.IVocabularyFactory"
       />
 
+  <utility
+      name="imio.smartweb.vocabulary.RemoteDirectoryEntities"
+      component=".vocabularies.RemoteDirectoryEntitiesVocabulary"
+      provides="zope.schema.interfaces.IVocabularyFactory"
+      />
+
 </configure>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a remote directory-backed entities vocabulary for content configuration, using a configurable “Directory base URL” Plone registry setting with fallback to a default environment URL.
* **Bug Fixes**
  * Reduced remote `@search` batch size to improve fetching reliability/performance.
* **Chores**
  * Introduced a GenericSetup upgrade path to add the new directory URL registry record and updated the profile version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->