### PR TITLE
SUP-53555 : Use schema.TextLine (with validator) instead of schema.Int

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.2.57 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- SUP-53555 : Use schema.TextLine (with validator) instead of schema.Int for zipcode field to avoid an awkward space 
+  (ex : 5 300 when editing the field) + upgrade steps
+  [boulch]
 
 
 1.2.56 (2026-07-07)

--- a/src/imio/smartweb/common/interfaces.py
+++ b/src/imio/smartweb/common/interfaces.py
@@ -9,6 +9,14 @@ from plone.app.z3cform.interfaces import IPloneFormLayer
 from plone.supermodel import model
 from plone.theme.interfaces import IDefaultPloneLayer
 from zope.interface import Interface
+from zope.interface import Invalid
+
+
+def validate_zipcode(value):
+    """Ensure that a zipcode only contains digits."""
+    if value and not value.isdigit():
+        raise Invalid(_("The zipcode must contain only digits."))
+    return True
 
 
 class IImioSmartwebCommonLayer(
@@ -35,7 +43,11 @@ class IAddress(model.Schema):
     street = schema.TextLine(title=_("Street"), required=False)
     number = schema.TextLine(title=_("Number"), required=False)
     complement = schema.TextLine(title=_("Complement"), required=False)
-    zipcode = schema.Int(title=_("Zipcode"), required=False)
+    zipcode = schema.TextLine(
+        title=_("Zipcode"),
+        required=False,
+        constraint=validate_zipcode,
+    )
     city = schema.TextLine(title=_("City"), required=False)
     country = schema.Choice(
         title=_("Country"),

--- a/src/imio/smartweb/common/profiles/default/metadata.xml
+++ b/src/imio/smartweb/common/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1042</version>
+  <version>1043</version>
   <dependencies>
     <dependency>profile-imio.omnia.core:default</dependency>
     <dependency>profile-plone.restapi:default</dependency>

--- a/src/imio/smartweb/common/upgrades/configure.zcml
+++ b/src/imio/smartweb/common/upgrades/configure.zcml
@@ -688,4 +688,13 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeStep
+      title="Migrate IAddress zipcode values from int to text"
+      description="The zipcode field changed from Int to TextLine; convert stored int values to strings."
+      profile="imio.smartweb.common:default"
+      source="1042"
+      destination="1043"
+      handler=".upgrades.migrate_zipcode_to_text"
+      />
+
 </configure>

--- a/src/imio/smartweb/common/upgrades/upgrades.py
+++ b/src/imio/smartweb/common/upgrades/upgrades.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from imio.smartweb.common.interfaces import IAddress
 from imio.smartweb.common.setuphandlers import set_omnia_core_settings
 from plone import api
 from plone.app.imagecropping import PAI_STORAGE_KEY
@@ -180,6 +181,28 @@ def set_effective_date_equal_to_created_date(context):
             obj = brain.getObject()
             obj.setEffectiveDate(obj.created())
             obj.reindexObject(idxs=["effective"])
+
+
+def migrate_zipcode_to_text(context):
+    """The IAddress zipcode field changed from Int to TextLine.
+
+    Existing content still stores the value as an int, which the text widget
+    would coerce on the fly but which is inconsistent (and breaks the new
+    digits-only constraint round-trip). Convert stored ints to strings once.
+    """
+    with api.env.adopt_user(username="admin"):
+        brains = api.content.find(object_provides=IAddress)
+        migrated = 0
+        for brain in brains:
+            obj = brain.getObject()
+            zipcode = getattr(obj, "zipcode", None)
+            if isinstance(zipcode, int):
+                obj.zipcode = str(zipcode)
+                migrated += 1
+                logger.info(
+                    f"Migrated zipcode {zipcode!r} -> {obj.zipcode!r} on {obj.absolute_url()}"
+                )
+        logger.info(f"Migrated {migrated} zipcode value(s) from int to text")
 
 
 def reindex_solr(context):


### PR DESCRIPTION
for zipcode field to avoid an awkward space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Zipcode fields now accept text input while still validating that only digits are entered.
  * Existing saved zipcodes are automatically converted so they continue to display and edit correctly.

* **Bug Fixes**
  * Prevents formatting issues when editing zipcodes, such as unwanted spaces appearing in the value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->